### PR TITLE
DEVEL: Modified to work with PyQt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ Alternatively the repository [psi\_fpga\_all](https://github.com/paulscherrerins
 ## External
 
 * PIP
-  * PyQt4
+  * PyQt5
   * pyparsing

--- a/TbGenGui.pyw
+++ b/TbGenGui.pyw
@@ -53,7 +53,7 @@ class TbGenGui(QDialog):
 
 
     def LoadSrc(self):
-        file = QFileDialog.getOpenFileName(parent=self, caption="Select Source File", directory=self.lastDirectory, filter="*.vhd")
+        file = QFileDialog.getOpenFileName(parent=self, caption="Select Source File", directory=self.lastDirectory, filter="*.vhd")[0]
         if file != "":
             self.srcLine.setText(file)
             self.lastDirectory = self.lastDirectory = os.path.dirname(file) + "/.." #Go one directory up because TB and SRT are usually stored in different folders

--- a/TbGenGui.pyw
+++ b/TbGenGui.pyw
@@ -4,7 +4,8 @@
 #  Authors: Oliver Bruendler
 ##############################################################################
 
-from PyQt4.QtGui import *
+from PyQt5.QtGui import *
+from PyQt5.QtWidgets import *
 import sys
 import os
 


### PR DESCRIPTION
I did the changes to work with PyQt5 becaus PyQt5 can be installed directly using PIP

```
pip3 install pyqt5
```

PyQt4 always had to be installed by manually download the wheel. For Python > 3.7, PyQt4 is not available at all.